### PR TITLE
added indices for cypress e2e testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
+    },
+    "devDependencies": {
+        "env-cmd": "^10.1.0"
     }
 }

--- a/src/layout/MainLayout/Sidebar/MenuCard/index.js
+++ b/src/layout/MainLayout/Sidebar/MenuCard/index.js
@@ -77,7 +77,7 @@ function LinearProgressWithLabel({ value, ...others }) {
                             </Typography>
                         </Grid>
                         <Grid item>
-                            <Typography variant="h6" color="inherit">{`${Math.round(value)}%`}</Typography>
+                            <Typography data-cy="configuration-progress-percentage" variant="h6" color="inherit">{`${Math.round(value)}%`}</Typography>
                         </Grid>
                     </Grid>
                 </Grid>

--- a/src/layout/MainLayout/Sidebar/MenuList/NavGroup/index.js
+++ b/src/layout/MainLayout/Sidebar/MenuList/NavGroup/index.js
@@ -32,6 +32,7 @@ const NavGroup = ({ item }) => {
     return (
         <>
             <List
+                data-cy="dApp-sub-section-sidebar-nav-studio"
                 subheader={
                     item.title && (
                         <Typography variant="caption" sx={{ ...theme.typography.menuCaption }} display="block" gutterBottom>

--- a/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.js
+++ b/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.js
@@ -56,6 +56,7 @@ const NavItem = ({ item, level }) => {
         <ListItemButton
             {...listItemProps}
             disabled={item.disabled}
+            data-cy={item.title}
             sx={{
                 borderRadius: `${customization.borderRadius}px`,
                 mb: 0.5,

--- a/src/layout/MainLayout/Sidebar/index.js
+++ b/src/layout/MainLayout/Sidebar/index.js
@@ -52,7 +52,7 @@ const Sidebar = ({ drawerOpen, drawerToggle, window }) => {
     const container = window !== undefined ? () => window.document.body : undefined;
 
     return (
-        <Box component="nav" sx={{ flexShrink: { md: 0 }, width: matchUpMd ? drawerWidth : 'auto' }} aria-label="mailbox folders">
+        <Box data-cy="sidebar-nav-studio" component="nav" sx={{ flexShrink: { md: 0 }, width: matchUpMd ? drawerWidth : 'auto' }} aria-label="mailbox folders">
             <Drawer
                 container={container}
                 variant={matchUpMd ? 'persistent' : 'temporary'}

--- a/src/views/application/DetailsApp.js
+++ b/src/views/application/DetailsApp.js
@@ -24,6 +24,7 @@ const DetailsApp = ({ project = {} }) => {
 
     return (
         <Paper
+            data-cy={`${project.config.name} box`}
             sx={{
                 borderRadius: 4,
                 p: 3,

--- a/src/views/marketplace/AddDialog.js
+++ b/src/views/marketplace/AddDialog.js
@@ -15,7 +15,7 @@ const AddDialog = ({ template, onClose, isOpen, }) => {
                     </DialogContentText>
                 </DialogContent>
             <DialogActions sx={{ p: 3, textAlign: 'center' }} justifyContent="center" alignItems="center">
-                <Button fullWidth variant="contained" href={getUrl(appState.subdomain, appState.type === template.id ? null : template.id)} target="_blank" color="info" sx={{ margin: '0 auto' }} onClick={onClose} autoFocus>
+                <Button data-cy="dialog-preview-my-dapp-button" fullWidth variant="contained" href={getUrl(appState.subdomain, appState.type === template.id ? null : template.id)} target="_blank" color="info" sx={{ margin: '0 auto' }} onClick={onClose} autoFocus>
                     Preview my dApp
                 </Button>
             </DialogActions>

--- a/src/views/marketplace/Options.js
+++ b/src/views/marketplace/Options.js
@@ -141,7 +141,8 @@ const Options = ({ id, readOnly=false }) => {
                             {!isInstalled && !readOnly && (
                                 <Grid item xs={12}>
                                     <Button variant="contained" 
-                                            color="secondary" 
+                                            color="secondary"
+                                            data-cy={`${template?.schema?.name} Install Button`}
                                             fullWidth 
                                             onClick={() => {
                                                 const newState = {...appState};

--- a/src/views/overview/index.js
+++ b/src/views/overview/index.js
@@ -117,7 +117,7 @@ const OverviewPage = () => {
                     <Typography variant="h2">Get started here!</Typography>
                     <Typography variant="body">Tell us more about your dApp</Typography>
                     <Paper variant="outlined" sx={{ p: 3, mt: 2 }} className="paper-in">
-                        <Grid container spacing={gridSpacing}>
+                        <Grid data-cy="get-started-name-and-description" container spacing={gridSpacing}>
                             <Grid item xs={12}>
                                 <TextField
                                     id="outlined-name"
@@ -130,6 +130,7 @@ const OverviewPage = () => {
                             <Grid item xs={12}>
                                 <TextField
                                     id="outlined-desc"
+                                    data-cy="project-description-textfield"
                                     label="Shortly, what is it about?"
                                     multiline
                                     rows={5}
@@ -173,6 +174,7 @@ const OverviewPage = () => {
                             <Grid item xs={6}>
                                 <TextField
                                     id="outlined-email"
+                                    data-cy="email-address-textfield"
                                     label="Email Address"
                                     value={appState?.social?.email}
                                     onChange={(e) => setSocial(dispatch, appState, 'email', e.target.value)}

--- a/src/views/projects/Projects.js
+++ b/src/views/projects/Projects.js
@@ -123,7 +123,7 @@ const Projects = () => {
 
     return (
         <Container sx={{ pb: 5 }}>
-            <Grid container spacing={gridSpacing} justifyContent="center" alignItems="center">
+            <Grid data-cy="created-dapps-overview" container spacing={gridSpacing} justifyContent="center" alignItems="center">
                 {listApps()}
                 {projects.length === 0 && welcome}
             </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5770,7 +5770,7 @@ commander@^2.20.0, commander@^2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.1.1:
+commander@^4.0.0, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -7011,6 +7011,14 @@ entities@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 errno@^0.1.3, errno@~0.1.1, errno@~0.1.7:
   version "0.1.8"


### PR DESCRIPTION
# Motivation
Cypress e2e tests best practice require `data-cy `properties for components. This PR adds this for the existing [e2e tests](https://github.com/DappifyWeb3/studio-e2e-tests).

> Targeting the element above by tag, class or id is very volatile and highly subject to change. You may swap out the element, you may refactor CSS and update ID's, or you may add or remove classes that affect the style of the element.
> 
> Instead, adding the data-cy attribute to the element gives us a targeted selector that's only used for testing.